### PR TITLE
Fixed GPL version in composer.json and improved installation manual

### DIFF
--- a/Resources/doc/INSTALL.md
+++ b/Resources/doc/INSTALL.md
@@ -102,18 +102,23 @@ assetic:
     bundles:        [ YuzuPipelineBundle ]
 ```
  
-- Dump assetic
- 
-```bash
-$> php ezpublish/console assets:install --symlink web
-$> php ezpublish/console assetic:dump --env=dev web
-$> php ezpublish/console assetic:dump --env=prod web
-```
- 
 - Clear cache
 
 ```bash
-$> php ezpublish/console cache:clear
+$> php ezpublish/console cache:clear --env=prod
 ```
+
+- Install additional assets
+
+```bash
+$> php ezpublish/console assets:install --symlink
+```
+
+- Dump assetic
+ 
+```bash
+$> php ezpublish/console assetic:dump --env=prod
+```
+ 
 
 - Enjoy!

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yuzu/pipelinebundle",
     "description": "One Page Theme for eZ Publish 5 and eZ Platform",
-    "license": "GPL-3.0",
+    "license": "GPL-2.0",
     "authors": [
         {
           "name": "Agence Yuzu"


### PR DESCRIPTION
- GPL version in composer.json was incorrect according to license file.
- Installation instructions was not in correct order (cache clearing should be first).
- Inserting `web` argument is not required as it's used by default.
